### PR TITLE
update to sample/zed SDK 3.0 or later

### DIFF
--- a/sample/zed/CMakeLists.txt
+++ b/sample/zed/CMakeLists.txt
@@ -6,7 +6,7 @@ message(STATUS ${CMAKE_MODULE_PATH})
 
 set(CMAKE_FIND_PACKAGE_SORT_ORDER NATURAL)
 
-find_package(ZED 2 REQUIRED)
+find_package(ZED 3 REQUIRED)
 find_package(CUDA ${ZED_CUDA_VERSION} REQUIRED)
 
 find_package(OpenCV REQUIRED)
@@ -21,6 +21,7 @@ include_directories(${ZED_INCLUDE_DIRS})
 
 link_directories(${ZED_LIBRARY_DIR})
 link_directories(${CUDA_LIBRARY_DIRS})
+link_directories(${OpenCV_LIBRARY_DIRS})
 
 if(NOT WIN32)
 	set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -std=c++11")

--- a/sample/zed/zed_demo.cpp
+++ b/sample/zed/zed_demo.cpp
@@ -53,39 +53,39 @@ int main(int argc, char* argv[]) {
 	
 	sl::Camera zed;
 	sl::InitParameters initParameters;
-	initParameters.camera_resolution = sl::RESOLUTION_VGA;
+	initParameters.camera_resolution = sl::RESOLUTION::VGA;
 	sl::ERROR_CODE err = zed.open(initParameters);
-	if (err != sl::SUCCESS) {
+	if (err != sl::ERROR_CODE::SUCCESS) {
 		std::cout << toString(err) << std::endl;
 		zed.close();
 		return 1;
 	}
-	const int width = static_cast<int>(zed.getResolution().width);
-	const int height = static_cast<int>(zed.getResolution().height);
+	const int width = static_cast<int>(zed.getCameraInformation().camera_configuration.resolution.width);
+	const int height = static_cast<int>(zed.getCameraInformation().camera_configuration.resolution.height);
 
-	sl::Mat d_zed_image_l(zed.getResolution(), sl::MAT_TYPE_8U_C1, sl::MEM_GPU);
-	sl::Mat d_zed_image_r(zed.getResolution(), sl::MAT_TYPE_8U_C1, sl::MEM_GPU);
+	sl::Mat d_zed_image_l(zed.getCameraInformation().camera_configuration.resolution, sl::MAT_TYPE::U8_C1, sl::MEM::GPU);
+	sl::Mat d_zed_image_r(zed.getCameraInformation().camera_configuration.resolution, sl::MAT_TYPE::U8_C1, sl::MEM::GPU);
 
 	const int input_depth = 8;
 	const int output_depth = 8;
 	const int output_bytes = output_depth * width * height / 8;
 
-	CV_Assert(d_zed_image_l.getStep(sl::MEM_GPU) == d_zed_image_r.getStep(sl::MEM_GPU));
-	sgm::StereoSGM sgm(width, height, disp_size, input_depth, output_depth, static_cast<int>(d_zed_image_l.getStep(sl::MEM_GPU)), width, sgm::EXECUTE_INOUT_CUDA2CUDA);
+	CV_Assert(d_zed_image_l.getStep(sl::MEM::GPU) == d_zed_image_r.getStep(sl::MEM::GPU));
+	sgm::StereoSGM sgm(width, height, disp_size, input_depth, output_depth, static_cast<int>(d_zed_image_l.getStep(sl::MEM::GPU)), width, sgm::EXECUTE_INOUT_CUDA2CUDA);
 
 	cv::Mat disparity(height, width, CV_8U);
 	cv::Mat disparity_8u, disparity_color;
 
 	device_buffer d_disparity(output_bytes);
 	while (1) {
-		if (zed.grab() == sl::SUCCESS) {
-			zed.retrieveImage(d_zed_image_l, sl::VIEW_LEFT_GRAY, sl::MEM_GPU);
-			zed.retrieveImage(d_zed_image_r, sl::VIEW_RIGHT_GRAY, sl::MEM_GPU);
+		if (zed.grab() == sl::ERROR_CODE::SUCCESS) {
+			zed.retrieveImage(d_zed_image_l, sl::VIEW::LEFT_GRAY, sl::MEM::GPU);
+			zed.retrieveImage(d_zed_image_r, sl::VIEW::RIGHT_GRAY, sl::MEM::GPU);
 		} else continue;
 
 		const auto t1 = std::chrono::system_clock::now();
 
-		sgm.execute(d_zed_image_l.getPtr<uchar>(sl::MEM_GPU), d_zed_image_r.getPtr<uchar>(sl::MEM_GPU), d_disparity.data);
+		sgm.execute(d_zed_image_l.getPtr<uchar>(sl::MEM::GPU), d_zed_image_r.getPtr<uchar>(sl::MEM::GPU), d_disparity.data);
 		cudaDeviceSynchronize();
 
 		const auto t2 = std::chrono::system_clock::now();


### PR DESCRIPTION
update to sample/zed SDK 3.0 or later, and test on NVIDIA jetson TX2, CUDA 10.2, ZED SDK 3.3, OpenCV 4.1.1, get 43.6 FPS.