### PR TITLE
Remove unused OpenCV dependency from test build

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,7 +6,6 @@ set(LIBSGM_SOURCE_DIR ${CMAKE_SOURCE_DIR}/src)
 
 # required packages
 find_package(CUDAToolkit REQUIRED)
-find_package(OpenCV REQUIRED)
 
 if (MSVC)
 	option(gtest_force_shared_crt "Force Gmock to use standard compiler flags" ON)
@@ -18,8 +17,8 @@ file(GLOB SRCS ./*.cpp ./*.cu ./*.h*)
 add_executable(sgm-test ${SRCS})
 
 target_compile_features(sgm-test PRIVATE cxx_std_17)
-target_include_directories(sgm-test PRIVATE ${LIBSGM_SOURCE_DIR} ${gtest_SOURCE_DIR}/include ${OpenCV_INCLUDE_DIRS})
-target_link_libraries(sgm-test sgm gtest ${OpenCV_LIBS})
+target_include_directories(sgm-test PRIVATE ${LIBSGM_SOURCE_DIR} ${gtest_SOURCE_DIR}/include)
+target_link_libraries(sgm-test sgm gtest)
 
 target_compile_options(
 	sgm-test PRIVATE


### PR DESCRIPTION
The `sgm-test` target requires OpenCV via `find_package(OpenCV REQUIRED)` and links `${OpenCV_LIBS}`, but no test source includes an OpenCV header or references any `cv::` symbol -- the tests build their inputs synthetically and compare GPU output against a CPU reference. The dependency is vestigial (carried over from the sample programs, which do use OpenCV).

Requiring OpenCV forces it to be installed to configure and build the tests on any platform, even though it contributes nothing to them. This drops the `find_package(OpenCV)` call and the `${OpenCV_INCLUDE_DIRS}` / `${OpenCV_LIBS}` references from the test target so the tests build with just CUDA and the SGM library.

This work was done with assistance from Claude (Anthropic).