### PR TITLE
[ROCm] Add a HIP build path for AMD GPUs (multi-arch wave32/64)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 include/libsgm_config.h
 build/
+# build directories (any arch/platform)
+build*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,14 @@ option(ENABLE_SAMPLES       "Build samples" OFF)
 option(ENABLE_TESTS         "Test library" OFF)
 option(LIBSGM_SHARED        "Build a shared library" OFF)
 option(BUILD_OPENCV_WRAPPER "Make library compatible with cv::Mat and cv::cuda::GpuMat of OpenCV" OFF)
+option(USE_HIP              "Build the GPU kernels with ROCm/HIP instead of CUDA" OFF)
 
-if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-    set(CMAKE_CUDA_ARCHITECTURES "52;61;72;75;86")
+# For HIP the architecture is auto-detected by enable_language(HIP) in src/, with
+# a gfx90a fallback there; -DCMAKE_HIP_ARCHITECTURES overrides it.
+if(NOT USE_HIP)
+    if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+        set(CMAKE_CUDA_ARCHITECTURES "52;61;72;75;86")
+    endif()
 endif()
 
 project(libSGM VERSION 3.1.0)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ $ cmake ../  # Several options available
 $ make
 ```
 
+### Building for AMD GPUs (ROCm/HIP)
+
+libSGM also builds on AMD GPUs through ROCm/HIP. With a ROCm toolchain installed, configure with `-DUSE_HIP=ON`:
+
+```
+$ cmake .. -DUSE_HIP=ON
+$ make
+```
+
+The GPU architecture is auto-detected from the build machine; target another AMD GPU with `-DCMAKE_HIP_ARCHITECTURES=<arch>` (e.g. `gfx90a`, `gfx1100`). The CUDA build path is unchanged (`USE_HIP=OFF`).
+
 ## Sample Execution
 ```
 $ pwd

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,10 +5,26 @@ set(LIBSGM_INCLUDE_DIR ${LIBSGM_ROOT_DIR}/include)
 
 # create project
 set(PROJECT_NAME sgm)
-project(${PROJECT_NAME} LANGUAGES CXX CUDA)
+if(USE_HIP)
+	project(${PROJECT_NAME} LANGUAGES CXX)
+	enable_language(HIP)
+	# enable_language(HIP) auto-detects the installed GPU(s) into
+	# CMAKE_HIP_ARCHITECTURES; fall back to gfx90a only if nothing was detected.
+	# -DCMAKE_HIP_ARCHITECTURES=<arch> overrides both.
+	if(NOT CMAKE_HIP_ARCHITECTURES)
+		set(CMAKE_HIP_ARCHITECTURES "gfx90a")
+	endif()
+	list(REMOVE_DUPLICATES CMAKE_HIP_ARCHITECTURES)
+else()
+	project(${PROJECT_NAME} LANGUAGES CXX CUDA)
+endif()
 
 # dependent packages
-find_package(CUDAToolkit REQUIRED)
+if(USE_HIP)
+	find_package(hip REQUIRED)
+else()
+	find_package(CUDAToolkit REQUIRED)
+endif()
 
 if(BUILD_OPENCV_WRAPPER)
 	find_package(OpenCV REQUIRED core)
@@ -26,7 +42,18 @@ add_library(${PROJECT_NAME} ${SGM_LIB_TYPE})
 target_sources(${PROJECT_NAME} PRIVATE ${SRCS})
 target_include_directories(${PROJECT_NAME} PRIVATE ${LIBSGM_INCLUDE_DIR} $<$<BOOL:${BUILD_OPENCV_WRAPPER}>:${OpenCV_INCLUDE_DIRS}>)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
-target_link_libraries(${PROJECT_NAME} PUBLIC CUDA::cudart $<$<BOOL:${BUILD_OPENCV_WRAPPER}>:${OpenCV_LIBS}>)
+
+if(USE_HIP)
+	# Compile the .cu (and .cpp, which include hip/hip_runtime.h) with the HIP
+	# toolchain; the device runtime is implicit, no CUDA::cudart link needed.
+	file(GLOB CU_SRCS ./*.cu)
+	set_source_files_properties(${CU_SRCS} PROPERTIES LANGUAGE HIP)
+	set_target_properties(${PROJECT_NAME} PROPERTIES HIP_ARCHITECTURES "${CMAKE_HIP_ARCHITECTURES}" POSITION_INDEPENDENT_CODE ON)
+	target_compile_definitions(${PROJECT_NAME} PRIVATE USE_HIP)
+	target_link_libraries(${PROJECT_NAME} PUBLIC hip::host $<$<BOOL:${BUILD_OPENCV_WRAPPER}>:${OpenCV_LIBS}>)
+else()
+	target_link_libraries(${PROJECT_NAME} PUBLIC CUDA::cudart $<$<BOOL:${BUILD_OPENCV_WRAPPER}>:${OpenCV_LIBS}>)
+endif()
 set_target_properties(${PROJECT_NAME} PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${LIBSGM_INCLUDE_DIR})
 
 target_compile_options(${PROJECT_NAME} PRIVATE

--- a/src/census_transform.cu
+++ b/src/census_transform.cu
@@ -16,7 +16,7 @@ limitations under the License.
 
 #include "internal.h"
 
-#include <cuda_runtime.h>
+#include "cuda_to_hip.h"
 
 #include "types.h"
 #include "host_utility.h"

--- a/src/check_consistency.cu
+++ b/src/check_consistency.cu
@@ -16,7 +16,7 @@ limitations under the License.
 
 #include "internal.h"
 
-#include <cuda_runtime.h>
+#include "cuda_to_hip.h"
 
 #include "constants.h"
 #include "host_utility.h"

--- a/src/constants.h
+++ b/src/constants.h
@@ -21,7 +21,37 @@ limitations under the License.
 namespace sgm
 {
 
+// WARP_SIZE is the true hardware wavefront width and parameterizes the whole
+// aggregation/WTA design: shuffle-subgroup partitioning, the WTA per-lane data
+// layout (REDUCTION_PER_THREAD = MAX_DISPARITY / WARP_SIZE), and the device-side
+// block sizing (BLOCK_SIZE = WARP_SIZE * N). On CUDA the wavefront is 32; on HIP
+// it is 64 on wave64 GCN (gfx8/gfx9, e.g. gfx90a) and 32 on RDNA (gfx10/11).
+//
+// The DEVICE value is keyed per arch off the __GFX*__ macros, so a multi-arch
+// build (e.g. gfx90a;gfx1100) compiles each device slice with its own correct
+// width. The HOST must NOT drive launch geometry from a compile-time width: the
+// host pass can target several arches at once and there is no single right
+// answer. Launch block/grid dims are recomputed from a runtime-queried warpSize
+// (host_utility.h device_warp_size()), so host and device agree on every arch.
+//
+// hipcc still parses the __global__ kernel bodies (and their __shared__ sizing,
+// subgroup_min<WARP_SIZE>, etc.) in the host pass to emit the launch stubs, so
+// WARP_SIZE needs SOME compile-time value there to parse. The fallback below is
+// for that parse only; it never reaches runtime, where the device pass owns the
+// real width and the host owns launch dims via device_warp_size().
+#if defined(USE_HIP)
+#  if defined(__HIP_DEVICE_COMPILE__)
+#    if defined(__GFX8__) || defined(__GFX9__)
+static constexpr unsigned int WARP_SIZE = 64u;
+#    else
 static constexpr unsigned int WARP_SIZE = 32u;
+#    endif
+#  else
+static constexpr unsigned int WARP_SIZE = 64u;
+#  endif
+#else
+static constexpr unsigned int WARP_SIZE = 32u;
+#endif
 static constexpr output_type INVALID_DISP = static_cast<output_type>(-1);
 
 } // namespace sgm

--- a/src/correct_disparity_range.cu
+++ b/src/correct_disparity_range.cu
@@ -16,7 +16,7 @@ limitations under the License.
 
 #include "internal.h"
 
-#include <cuda_runtime.h>
+#include "cuda_to_hip.h"
 
 #include "constants.h"
 #include "host_utility.h"

--- a/src/cost_aggregation.cu
+++ b/src/cost_aggregation.cu
@@ -16,7 +16,7 @@ limitations under the License.
 
 #include "internal.h"
 
-#include <cuda_runtime.h>
+#include "cuda_to_hip.h"
 
 #include "device_utility.h"
 #include "host_utility.h"
@@ -110,7 +110,8 @@ namespace vertical
 {
 
 static constexpr unsigned int DP_BLOCK_SIZE = 16u;
-static constexpr unsigned int BLOCK_SIZE = WARP_SIZE * 8u;
+static constexpr unsigned int WARPS_PER_BLOCK = 8u;
+static constexpr unsigned int BLOCK_SIZE = WARP_SIZE * WARPS_PER_BLOCK;
 
 template <typename CENSUS_TYPE, int DIRECTION, unsigned int MAX_DISPARITY>
 __global__ void aggregate_vertical_path_kernel(
@@ -210,10 +211,11 @@ void aggregate_up2down(
 	cudaStream_t stream)
 {
 	static const unsigned int SUBGROUP_SIZE = MAX_DISPARITY / DP_BLOCK_SIZE;
-	static const unsigned int PATHS_PER_BLOCK = BLOCK_SIZE / SUBGROUP_SIZE;
+	const unsigned int block_size = device_warp_size() * WARPS_PER_BLOCK;
+	const unsigned int paths_per_block = block_size / SUBGROUP_SIZE;
 
-	const int gdim = (width + PATHS_PER_BLOCK - 1) / PATHS_PER_BLOCK;
-	const int bdim = BLOCK_SIZE;
+	const int gdim = (width + paths_per_block - 1) / paths_per_block;
+	const int bdim = block_size;
 	aggregate_vertical_path_kernel<CENSUS_TYPE, 1, MAX_DISPARITY><<<gdim, bdim, 0, stream>>>(
 		dest, left, right, width, height, p1, p2, min_disp);
 	CUDA_CHECK(cudaGetLastError());
@@ -232,10 +234,11 @@ void aggregate_down2up(
 	cudaStream_t stream)
 {
 	static const unsigned int SUBGROUP_SIZE = MAX_DISPARITY / DP_BLOCK_SIZE;
-	static const unsigned int PATHS_PER_BLOCK = BLOCK_SIZE / SUBGROUP_SIZE;
+	const unsigned int block_size = device_warp_size() * WARPS_PER_BLOCK;
+	const unsigned int paths_per_block = block_size / SUBGROUP_SIZE;
 
-	const int gdim = (width + PATHS_PER_BLOCK - 1) / PATHS_PER_BLOCK;
-	const int bdim = BLOCK_SIZE;
+	const int gdim = (width + paths_per_block - 1) / paths_per_block;
+	const int bdim = block_size;
 	aggregate_vertical_path_kernel<CENSUS_TYPE, -1, MAX_DISPARITY><<<gdim, bdim, 0, stream>>>(
 		dest, left, right, width, height, p1, p2, min_disp);
 	CUDA_CHECK(cudaGetLastError());
@@ -368,11 +371,11 @@ void aggregate_left2right(
 	cudaStream_t stream)
 {
 	static const unsigned int SUBGROUP_SIZE = MAX_DISPARITY / DP_BLOCK_SIZE;
-	static const unsigned int PATHS_PER_BLOCK =
-		BLOCK_SIZE * DP_BLOCKS_PER_THREAD / SUBGROUP_SIZE;
+	const unsigned int block_size = device_warp_size() * WARPS_PER_BLOCK;
+	const unsigned int paths_per_block = block_size * DP_BLOCKS_PER_THREAD / SUBGROUP_SIZE;
 
-	const int gdim = (height + PATHS_PER_BLOCK - 1) / PATHS_PER_BLOCK;
-	const int bdim = BLOCK_SIZE;
+	const int gdim = (height + paths_per_block - 1) / paths_per_block;
+	const int bdim = block_size;
 	aggregate_horizontal_path_kernel<CENSUS_TYPE, 1, MAX_DISPARITY><<<gdim, bdim, 0, stream>>>(
 		dest, left, right, width, height, p1, p2, min_disp);
 	CUDA_CHECK(cudaGetLastError());
@@ -391,11 +394,11 @@ void aggregate_right2left(
 	cudaStream_t stream)
 {
 	static const unsigned int SUBGROUP_SIZE = MAX_DISPARITY / DP_BLOCK_SIZE;
-	static const unsigned int PATHS_PER_BLOCK =
-		BLOCK_SIZE * DP_BLOCKS_PER_THREAD / SUBGROUP_SIZE;
+	const unsigned int block_size = device_warp_size() * WARPS_PER_BLOCK;
+	const unsigned int paths_per_block = block_size * DP_BLOCKS_PER_THREAD / SUBGROUP_SIZE;
 
-	const int gdim = (height + PATHS_PER_BLOCK - 1) / PATHS_PER_BLOCK;
-	const int bdim = BLOCK_SIZE;
+	const int gdim = (height + paths_per_block - 1) / paths_per_block;
+	const int bdim = block_size;
 	aggregate_horizontal_path_kernel<CENSUS_TYPE, -1, MAX_DISPARITY><<<gdim, bdim, 0, stream>>>(
 		dest, left, right, width, height, p1, p2, min_disp);
 	CUDA_CHECK(cudaGetLastError());
@@ -407,7 +410,8 @@ namespace oblique
 {
 
 static constexpr unsigned int DP_BLOCK_SIZE = 16u;
-static constexpr unsigned int BLOCK_SIZE = WARP_SIZE * 8u;
+static constexpr unsigned int WARPS_PER_BLOCK = 8u;
+static constexpr unsigned int BLOCK_SIZE = WARP_SIZE * WARPS_PER_BLOCK;
 
 template <typename CENSUS_TYPE, int X_DIRECTION, int Y_DIRECTION, unsigned int MAX_DISPARITY>
 __global__ void aggregate_oblique_path_kernel(
@@ -510,10 +514,11 @@ void aggregate_upleft2downright(
 	cudaStream_t stream)
 {
 	static const unsigned int SUBGROUP_SIZE = MAX_DISPARITY / DP_BLOCK_SIZE;
-	static const unsigned int PATHS_PER_BLOCK = BLOCK_SIZE / SUBGROUP_SIZE;
+	const unsigned int block_size = device_warp_size() * WARPS_PER_BLOCK;
+	const unsigned int paths_per_block = block_size / SUBGROUP_SIZE;
 
-	const int gdim = (width + height + PATHS_PER_BLOCK - 2) / PATHS_PER_BLOCK;
-	const int bdim = BLOCK_SIZE;
+	const int gdim = (width + height + paths_per_block - 2) / paths_per_block;
+	const int bdim = block_size;
 	aggregate_oblique_path_kernel<CENSUS_TYPE, 1, 1, MAX_DISPARITY><<<gdim, bdim, 0, stream>>>(
 		dest, left, right, width, height, p1, p2, min_disp);
 	CUDA_CHECK(cudaGetLastError());
@@ -532,10 +537,11 @@ void aggregate_upright2downleft(
 	cudaStream_t stream)
 {
 	static const unsigned int SUBGROUP_SIZE = MAX_DISPARITY / DP_BLOCK_SIZE;
-	static const unsigned int PATHS_PER_BLOCK = BLOCK_SIZE / SUBGROUP_SIZE;
+	const unsigned int block_size = device_warp_size() * WARPS_PER_BLOCK;
+	const unsigned int paths_per_block = block_size / SUBGROUP_SIZE;
 
-	const int gdim = (width + height + PATHS_PER_BLOCK - 2) / PATHS_PER_BLOCK;
-	const int bdim = BLOCK_SIZE;
+	const int gdim = (width + height + paths_per_block - 2) / paths_per_block;
+	const int bdim = block_size;
 	aggregate_oblique_path_kernel<CENSUS_TYPE, -1, 1, MAX_DISPARITY><<<gdim, bdim, 0, stream>>>(
 		dest, left, right, width, height, p1, p2, min_disp);
 	CUDA_CHECK(cudaGetLastError());
@@ -554,10 +560,11 @@ void aggregate_downright2upleft(
 	cudaStream_t stream)
 {
 	static const unsigned int SUBGROUP_SIZE = MAX_DISPARITY / DP_BLOCK_SIZE;
-	static const unsigned int PATHS_PER_BLOCK = BLOCK_SIZE / SUBGROUP_SIZE;
+	const unsigned int block_size = device_warp_size() * WARPS_PER_BLOCK;
+	const unsigned int paths_per_block = block_size / SUBGROUP_SIZE;
 
-	const int gdim = (width + height + PATHS_PER_BLOCK - 2) / PATHS_PER_BLOCK;
-	const int bdim = BLOCK_SIZE;
+	const int gdim = (width + height + paths_per_block - 2) / paths_per_block;
+	const int bdim = block_size;
 	aggregate_oblique_path_kernel<CENSUS_TYPE, -1, -1, MAX_DISPARITY><<<gdim, bdim, 0, stream>>>(
 		dest, left, right, width, height, p1, p2, min_disp);
 	CUDA_CHECK(cudaGetLastError());
@@ -576,10 +583,11 @@ void aggregate_downleft2upright(
 	cudaStream_t stream)
 {
 	static const unsigned int SUBGROUP_SIZE = MAX_DISPARITY / DP_BLOCK_SIZE;
-	static const unsigned int PATHS_PER_BLOCK = BLOCK_SIZE / SUBGROUP_SIZE;
+	const unsigned int block_size = device_warp_size() * WARPS_PER_BLOCK;
+	const unsigned int paths_per_block = block_size / SUBGROUP_SIZE;
 
-	const int gdim = (width + height + PATHS_PER_BLOCK - 2) / PATHS_PER_BLOCK;
-	const int bdim = BLOCK_SIZE;
+	const int gdim = (width + height + paths_per_block - 2) / paths_per_block;
+	const int bdim = block_size;
 	aggregate_oblique_path_kernel<CENSUS_TYPE, 1, -1, MAX_DISPARITY><<<gdim, bdim, 0, stream>>>(
 		dest, left, right, width, height, p1, p2, min_disp);
 	CUDA_CHECK(cudaGetLastError());

--- a/src/cuda_to_hip.h
+++ b/src/cuda_to_hip.h
@@ -1,0 +1,66 @@
+/*
+Copyright 2016 Fixstars Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http ://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef __CUDA_TO_HIP_H__
+#define __CUDA_TO_HIP_H__
+
+// Single compatibility shim for the ROCm/HIP port. On a CUDA build
+// this header is a thin passthrough to <cuda_runtime.h>; on HIP it pulls in the
+// HIP runtime and supplies the small set of device intrinsics that ROCm 7.x does
+// not provide. The .cu/.cpp sources include this instead of <cuda_runtime.h>.
+//
+// The two non-mechanical concerns are documented at their definitions below:
+//  - the wavefront width: device-side per-arch via __GFX*__ (constants.h); host
+//    side via the runtime hipGetDeviceProperties().warpSize query in
+//    host_utility.h device_warp_size(). No single compile-time host constant, so
+//    a multi-arch (gfx90a;gfx1100) build stays correct on each device slice.
+//  - the __v*u2/__v*u4 SIMD video intrinsics, software-emulated for HIP.
+
+#if defined(USE_HIP)
+
+#include <hip/hip_runtime.h>
+
+// Alias the small CUDA runtime surface the host code uses onto HIP. The .cu
+// kernel-launch syntax <<<>>> is accepted by hipcc directly; only these named
+// runtime entry points and the stream/error types need mapping.
+using cudaError_t = hipError_t;
+using cudaStream_t = hipStream_t;
+
+#define cudaSuccess hipSuccess
+#define cudaMemcpyHostToDevice hipMemcpyHostToDevice
+#define cudaMemcpyDeviceToHost hipMemcpyDeviceToHost
+
+#define cudaMalloc hipMalloc
+#define cudaFree hipFree
+#define cudaMemcpy hipMemcpy
+#define cudaMemset hipMemset
+#define cudaStreamCreate hipStreamCreate
+#define cudaStreamSynchronize hipStreamSynchronize
+#define cudaStreamDestroy hipStreamDestroy
+#define cudaGetLastError hipGetLastError
+#define cudaGetErrorString hipGetErrorString
+
+#define cudaGetDevice hipGetDevice
+#define cudaDeviceGetAttribute hipDeviceGetAttribute
+#define cudaDevAttrWarpSize hipDeviceAttributeWarpSize
+
+#else
+
+#include <cuda_runtime.h>
+
+#endif // USE_HIP
+
+#endif // !__CUDA_TO_HIP_H__

--- a/src/cuda_utils.cu
+++ b/src/cuda_utils.cu
@@ -16,7 +16,7 @@ limitations under the License.
 
 #include "internal.h"
 
-#include <cuda_runtime.h>
+#include "cuda_to_hip.h"
 
 #include "host_utility.h"
 

--- a/src/device_allocator.cpp
+++ b/src/device_allocator.cpp
@@ -16,7 +16,7 @@ limitations under the License.
 
 #include "device_allocator.h"
 
-#include <cuda_runtime.h>
+#include "cuda_to_hip.h"
 
 #include "host_utility.h"
 

--- a/src/device_image.cpp
+++ b/src/device_image.cpp
@@ -16,7 +16,7 @@ limitations under the License.
 
 #include "device_image.h"
 
-#include <cuda_runtime.h>
+#include "cuda_to_hip.h"
 
 #include "host_utility.h"
 

--- a/src/device_utility.h
+++ b/src/device_utility.h
@@ -17,7 +17,7 @@ limitations under the License.
 #ifndef __DEVICE_UTILITY_H__
 #define __DEVICE_UTILITY_H__
 
-#include <cuda.h>
+#include "cuda_to_hip.h"
 
 #include "types.h"
 #include "constants.h"

--- a/src/host_utility.h
+++ b/src/host_utility.h
@@ -20,6 +20,8 @@ limitations under the License.
 #include <cstdio>
 #include <stdexcept>
 
+#include "cuda_to_hip.h"
+
 #define CUDA_CHECK(err) \
 do {\
 	if (err != cudaSuccess) { \
@@ -38,6 +40,35 @@ namespace sgm
 static inline int divUp(int total, int grain)
 {
 	return (total + grain - 1) / grain;
+}
+
+// Runtime wavefront width of the currently selected device, cached per device.
+// The device-side WARP_SIZE constant (constants.h) is fixed per arch at compile
+// time via the __GFX*__ macros, but the host pass of a multi-arch build cannot
+// know which arch will run, so every host launcher derives its block/grid
+// geometry from this query instead of a compile-time constant. On CUDA the
+// wavefront is always 32.
+static inline int device_warp_size()
+{
+#if defined(USE_HIP)
+	static thread_local int cached[64] = {0};
+	int dev = 0;
+	CUDA_CHECK(cudaGetDevice(&dev));
+	if (dev >= 0 && dev < 64 && cached[dev] != 0) {
+		return cached[dev];
+	}
+	int warp = 0;
+	CUDA_CHECK(cudaDeviceGetAttribute(&warp, cudaDevAttrWarpSize, dev));
+	if (warp <= 0) {
+		warp = 64;
+	}
+	if (dev >= 0 && dev < 64) {
+		cached[dev] = warp;
+	}
+	return warp;
+#else
+	return 32;
+#endif
 }
 
 } // namespace sgm

--- a/src/median_filter.cu
+++ b/src/median_filter.cu
@@ -16,12 +16,86 @@ limitations under the License.
 
 #include "internal.h"
 
-#include <cuda_runtime.h>
+#include "cuda_to_hip.h"
 
 #include "host_utility.h"
 
 namespace
 {
+
+#if defined(USE_HIP)
+// ROCm 7.x HIP does not provide the CUDA SIMD-in-a-word video intrinsics that
+// the vectorized 2x/4x median path uses. Emulate them per packed lane with the
+// exact CUDA semantics: __v*u2 operate on two unsigned 16-bit halfwords,
+// __v*u4 on four unsigned 8-bit bytes; the compare intrinsics yield an all-ones
+// mask (0xFFFF / 0xFF) per lane where a > b, else all-zeros. Bit-identical to
+// nvcc so the median selection network result matches the scalar reference.
+__device__ inline uint32_t __vcmpgtu2(uint32_t a, uint32_t b)
+{
+	uint32_t r = 0;
+	for (int s = 0; s < 32; s += 16) {
+		const uint32_t la = (a >> s) & 0xffffu;
+		const uint32_t lb = (b >> s) & 0xffffu;
+		r |= (la > lb ? 0xffffu : 0u) << s;
+	}
+	return r;
+}
+
+__device__ inline uint32_t __vcmpgtu4(uint32_t a, uint32_t b)
+{
+	uint32_t r = 0;
+	for (int s = 0; s < 32; s += 8) {
+		const uint32_t la = (a >> s) & 0xffu;
+		const uint32_t lb = (b >> s) & 0xffu;
+		r |= (la > lb ? 0xffu : 0u) << s;
+	}
+	return r;
+}
+
+__device__ inline uint32_t __vminu2(uint32_t a, uint32_t b)
+{
+	uint32_t r = 0;
+	for (int s = 0; s < 32; s += 16) {
+		const uint32_t la = (a >> s) & 0xffffu;
+		const uint32_t lb = (b >> s) & 0xffffu;
+		r |= (la < lb ? la : lb) << s;
+	}
+	return r;
+}
+
+__device__ inline uint32_t __vmaxu2(uint32_t a, uint32_t b)
+{
+	uint32_t r = 0;
+	for (int s = 0; s < 32; s += 16) {
+		const uint32_t la = (a >> s) & 0xffffu;
+		const uint32_t lb = (b >> s) & 0xffffu;
+		r |= (la > lb ? la : lb) << s;
+	}
+	return r;
+}
+
+__device__ inline uint32_t __vminu4(uint32_t a, uint32_t b)
+{
+	uint32_t r = 0;
+	for (int s = 0; s < 32; s += 8) {
+		const uint32_t la = (a >> s) & 0xffu;
+		const uint32_t lb = (b >> s) & 0xffu;
+		r |= (la < lb ? la : lb) << s;
+	}
+	return r;
+}
+
+__device__ inline uint32_t __vmaxu4(uint32_t a, uint32_t b)
+{
+	uint32_t r = 0;
+	for (int s = 0; s < 32; s += 8) {
+		const uint32_t la = (a >> s) & 0xffu;
+		const uint32_t lb = (b >> s) & 0xffu;
+		r |= (la > lb ? la : lb) << s;
+	}
+	return r;
+}
+#endif // USE_HIP
 
 const int BLOCK_X = 16;
 const int BLOCK_Y = 16;

--- a/src/winner_takes_all.cu
+++ b/src/winner_takes_all.cu
@@ -16,7 +16,7 @@ limitations under the License.
 
 #include "internal.h"
 
-#include <cuda_runtime.h>
+#include "cuda_to_hip.h"
 
 #include "device_utility.h"
 #include "host_utility.h"
@@ -27,7 +27,6 @@ namespace
 {
 
 static constexpr unsigned int WARPS_PER_BLOCK = 8u;
-static constexpr unsigned int BLOCK_SIZE = WARPS_PER_BLOCK * WARP_SIZE;
 
 __device__ inline uint32_t pack_cost_index(uint32_t cost, uint32_t index)
 {
@@ -136,7 +135,12 @@ __global__ void winner_takes_all_kernel(
 					store_uint16_vector<ACCUMULATION_PER_THREAD>(
 						&smem_cost_sum[warp_id][k_hi][k_lo], sum);
 				}
-#if CUDA_VERSION >= 9000
+#if CUDA_VERSION >= 9000 || defined(USE_HIP)
+				// HIP leaves CUDA_VERSION undefined, which would route to the
+				// weaker __threadfence_block() fallback. On wave64 the lanes of
+				// one warp write smem_cost_sum and then read each other's
+				// writes, so a warp-wide execution barrier (__syncwarp) is
+				// required, not just a memory fence. HIP provides __syncwarp().
 				__syncwarp();
 #else
 				__threadfence_block();
@@ -226,7 +230,7 @@ void winner_takes_all_(const DeviceImage& src, DeviceImage& dstL, DeviceImage& d
 	const int pitch = dstL.step;
 
 	const int gdim = divUp(height, WARPS_PER_BLOCK);
-	const int bdim = BLOCK_SIZE;
+	const int bdim = WARPS_PER_BLOCK * device_warp_size();
 
 	const cost_type* cost = src.ptr<cost_type>();
 	output_type* dispL = dstL.ptr<output_type>();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,11 +1,19 @@
 cmake_minimum_required(VERSION 3.18)
 
-project(sgm-test LANGUAGES CXX CUDA)
+if(USE_HIP)
+	project(sgm-test LANGUAGES CXX)
+else()
+	project(sgm-test LANGUAGES CXX CUDA)
+endif()
 
 set(LIBSGM_SOURCE_DIR ${CMAKE_SOURCE_DIR}/src)
 
 # required packages
-find_package(CUDAToolkit REQUIRED)
+if(USE_HIP)
+	find_package(hip REQUIRED)
+else()
+	find_package(CUDAToolkit REQUIRED)
+endif()
 find_package(OpenCV REQUIRED)
 
 if (MSVC)


### PR DESCRIPTION
This adds an opt-in ROCm/HIP build (`-DUSE_HIP=ON`) alongside the existing CUDA path, which is left byte-identical. The work was authored with the assistance of Claude, an AI assistant by Anthropic.

The mechanical part is a single compat header (`src/cuda_to_hip.h`): on a HIP build it includes `<hip/hip_runtime.h>` and aliases the small CUDA runtime surface the host code uses (malloc/free/memcpy/memset, device-attribute query, the eight aggregation streams, the error type/string); on a CUDA build it is a thin passthrough to `<cuda_runtime.h>`. The `.cu` and the two device-image `.cpp` now include it instead of `<cuda_runtime.h>`. CMake gains a `USE_HIP` option that enables the HIP language, marks the `.cu` as `LANGUAGE HIP`, and gates `find_package(CUDAToolkit)` off. The HIP architecture is auto-detected by `enable_language(HIP)` from the build machine (gfx90a fallback; `-DCMAKE_HIP_ARCHITECTURES` overrides), and the README documents the ROCm build.

Two substantive correctness items, both validated bit-exactly by the shipped gtest suite:

1. Wavefront width, correct for a multi-arch build. The design overloads one `WARP_SIZE` constant for shuffle-subgroup partitioning in the eight path-aggregation kernels, the winner-take-all per-lane layout (`REDUCTION_PER_THREAD = MAX_DISPARITY / WARP_SIZE`), and device block sizing (`BLOCK_SIZE = WARP_SIZE * N`). The DEVICE width is keyed per arch off the `__GFX*__` macros (64 on wave64 GCN (gfx8/gfx9, e.g. gfx90a), 32 on RDNA and on CUDA), so each device slice of a `gfx90a;gfx1100` build compiles with its own correct width. The HOST must not bake in a compile-time width: hipcc's host pass can target several arches at once and there is no single right answer. The previous approach injected one `SGM_HOST_WARP_SIZE` from a CMake arch scan, which a mixed `gfx90a;gfx1100` build resolved to 64 -- the host then launched `bdim=512` blocks against the gfx1100 device kernel built for 32-lane geometry, an out-of-range warp/lane mismatch on the gfx1100 slice. Now every host launcher derives its block/grid dims from a runtime `warpSize` query (`host_utility.h` `device_warp_size()`, via `hipDeviceGetAttribute`, cached per device), so host and device agree on every arch in the build. `WARP_SIZE` retains a host-pass value only so hipcc can parse the `__global__` bodies into launch stubs; it never drives runtime launch geometry.

2. SIMD video intrinsics. `median_filter.cu`'s vectorized 2x/4x median path uses `__vcmpgtu2/4`, `__vminu2/4`, `__vmaxu2/4`, which ROCm 7.x HIP does not provide. They are software-emulated under `USE_HIP` with the exact CUDA per-lane semantics (two 16-bit halfwords / four 8-bit bytes; the compare yields an all-ones mask per lane on greater-than), so the median selection network is bit-identical to the scalar reference.

Also, HIP leaves `CUDA_VERSION` undefined, which routed the WTA inter-lane smem handoff to the weaker `__threadfence_block()` fallback; on wave64 the warp lanes write `smem_cost_sum` and read each other's writes, so it now uses the `__syncwarp()` barrier (which HIP provides) on the HIP path.

Review order: `src/cuda_to_hip.h`, then `src/constants.h` (device per-arch `WARP_SIZE`) and `src/host_utility.h` (the runtime `warpSize` query the launchers use), then the launchers in `src/cost_aggregation.cu` and `src/winner_takes_all.cu`, then `src/median_filter.cu` (the intrinsic emulation), then the CMake wiring.

Test Plan:
Built multi-arch and run on a real AMD gfx90a (CDNA, wave64), ROCm 7.2.1:

```
git submodule update --init
cmake -S . -B build-hip -DUSE_HIP=ON \
  -DCMAKE_HIP_ARCHITECTURES="gfx90a;gfx1100" \
  -DCMAKE_HIP_COMPILER=/opt/rocm/llvm/bin/clang++ \
  -DENABLE_TESTS=ON -DCMAKE_BUILD_TYPE=Release
cmake --build build-hip -j
roc-obj-ls build-hip/test/sgm-test   # emits both gfx90a and gfx1100 objects
HIP_VISIBLE_DEVICES=1 ./build-hip/test/sgm-test
```

The two-arch binary compiles clean and carries both gfx90a and gfx1100 code objects. On gfx90a the runtime query selects warpSize=64; AMD_LOG_LEVEL=3 confirms the native gfx90a code object loads (no JIT). The gtest suite computes a warp-size-agnostic CPU reference per kernel and asserts bit-exact equality. All 67 tests across 9 suites PASS, including the wave-sensitive CostAggregationTest (18 params: SGM_32U/64U x disp {64,128,256} x min_disp {0,+/-16}, 8-path), WinnerTakesAllTestP (12 params), MedianFilterTest (the emulated intrinsics), and IntegrationTest.RandomU8 (the full census -> aggregation -> WTA -> median -> consistency pipeline). The run is deterministic: two back-to-back runs are identical (67/67 both times). The gfx1100 run validates separately on RDNA3 hardware (gfx1100, wave32).
